### PR TITLE
feat: enhance HTTP/2 pseudo-header handling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -343,6 +343,11 @@ pub struct Builder {
     ///
     /// When this gets exceeded, we issue GOAWAYs.
     local_max_error_reset_streams: Option<usize>,
+
+    /// [impit patch] Per-connection pseudo-header order for HEADERS frames.
+    /// E.g. Chrome uses `:method, :authority, :scheme, :path`,
+    /// while Firefox uses `:method, :path, :authority, :scheme`.
+    pseudo_header_order: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -653,7 +658,15 @@ impl Builder {
     /// # pub fn main() {}
     /// ```
     pub fn new() -> Builder {
-        Builder {
+        // [impit patch] Read pseudo-header order from env var at connection creation time.
+        // This value is stored per-connection in the Codec, so once the connection is
+        // established, the env var can change without affecting this connection.
+        // This is a significant improvement over reading the env var on every HEADERS frame.
+        let pseudo_header_order = std::env::var("IMPIT_H2_PSEUDOHEADERS_ORDER").ok().map(|val| {
+            val.split(',').map(|s| s.to_string()).collect::<Vec<String>>()
+        });
+
+        let mut builder = Builder {
             max_send_buffer_size: proto::DEFAULT_MAX_SEND_BUFFER_SIZE,
             reset_stream_duration: Duration::from_secs(proto::DEFAULT_RESET_STREAM_SECS),
             reset_stream_max: proto::DEFAULT_RESET_STREAM_MAX,
@@ -663,7 +676,27 @@ impl Builder {
             settings: Default::default(),
             stream_id: 1.into(),
             local_max_error_reset_streams: Some(proto::DEFAULT_LOCAL_RESET_COUNT_MAX),
+            pseudo_header_order,
+        };
+
+        // [impit patch] Set HEADER_TABLE_SIZE=65536 as the default.
+        // Real browsers (Chrome, Firefox, Edge) all send HEADER_TABLE_SIZE=65536
+        // in their SETTINGS frame. The h2 crate default of 4096 is a dead giveaway
+        // that the client is not a real browser. This is safe to set as a global
+        // default because ALL browsers use the same value.
+        builder.header_table_size(65536);
+
+        // [impit patch] Read MAX_CONCURRENT_STREAMS from env var.
+        // Chrome sends MAX_CONCURRENT_STREAMS=1000, Firefox doesn't send it.
+        // reqwest doesn't expose this setting, so we read it via env var
+        // (same approach as pseudo-header order -- read once per connection).
+        if let Ok(val) = std::env::var("IMPIT_H2_MAX_CONCURRENT_STREAMS") {
+            if let Ok(v) = val.parse::<u32>() {
+                builder.max_concurrent_streams(v);
+            }
         }
+
+        builder
     }
 
     /// Indicates the initial window size (in octets) for stream-level
@@ -1145,6 +1178,19 @@ impl Builder {
         self
     }
 
+    /// [impit patch] Sets the pseudo-header order for HEADERS frames.
+    ///
+    /// Different browsers use different pseudo-header orders:
+    /// - Chrome/Edge: `:method, :authority, :scheme, :path`
+    /// - Firefox: `:method, :path, :authority, :scheme`
+    ///
+    /// The order is stored per-connection, making it safe for multiple
+    /// concurrent connections with different browser fingerprints.
+    pub fn pseudo_header_order(&mut self, order: Vec<String>) -> &mut Self {
+        self.pseudo_header_order = Some(order);
+        self
+    }
+
     /// Sets the first stream ID to something other than 1.
     #[cfg(feature = "unstable")]
     pub fn initial_stream_id(&mut self, stream_id: u32) -> &mut Self {
@@ -1317,6 +1363,11 @@ where
 
         if let Some(max) = builder.settings.max_header_list_size() {
             codec.set_max_recv_header_list_size(max as usize);
+        }
+
+        // [impit patch] Set per-connection pseudo-header order
+        if let Some(order) = builder.pseudo_header_order.clone() {
+            codec.set_pseudo_header_order(order);
         }
 
         // Send initial settings frame

--- a/src/client.rs
+++ b/src/client.rs
@@ -662,9 +662,13 @@ impl Builder {
         // This value is stored per-connection in the Codec, so once the connection is
         // established, the env var can change without affecting this connection.
         // This is a significant improvement over reading the env var on every HEADERS frame.
-        let pseudo_header_order = std::env::var("IMPIT_H2_PSEUDOHEADERS_ORDER").ok().map(|val| {
-            val.split(',').map(|s| s.to_string()).collect::<Vec<String>>()
-        });
+        let pseudo_header_order = std::env::var("IMPIT_H2_PSEUDOHEADERS_ORDER")
+            .ok()
+            .map(|val| {
+                val.split(',')
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>()
+            });
 
         let mut builder = Builder {
             max_send_buffer_size: proto::DEFAULT_MAX_SEND_BUFFER_SIZE,

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -52,6 +52,11 @@ struct Encoder<B> {
 
     /// Min buffer required to attempt to write a frame
     min_buffer_capacity: usize,
+
+    /// [impit patch] Per-connection pseudo-header order for HEADERS frames.
+    /// This replaces the process-global env var approach to allow multiple
+    /// concurrent h2 connections with different browser fingerprints.
+    pseudo_header_order: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -99,6 +104,7 @@ where
                 max_frame_size: frame::DEFAULT_MAX_FRAME_SIZE,
                 chain_threshold,
                 min_buffer_capacity: chain_threshold + frame::HEADER_LEN,
+                pseudo_header_order: None,
             },
         }
     }
@@ -252,13 +258,13 @@ where
             }
             Frame::Headers(v) => {
                 let mut buf = limited_write_buf!(self);
-                if let Some(continuation) = v.encode(&mut self.hpack, &mut buf) {
+                if let Some(continuation) = v.encode(&mut self.hpack, self.pseudo_header_order.as_deref(), &mut buf) {
                     self.next = Some(Next::Continuation(continuation));
                 }
             }
             Frame::PushPromise(v) => {
                 let mut buf = limited_write_buf!(self);
-                if let Some(continuation) = v.encode(&mut self.hpack, &mut buf) {
+                if let Some(continuation) = v.encode(&mut self.hpack, self.pseudo_header_order.as_deref(), &mut buf) {
                     self.next = Some(Next::Continuation(continuation));
                 }
             }
@@ -335,6 +341,11 @@ impl<T, B> FramedWrite<T, B> {
     /// Retrieve the last data frame that has been sent
     pub fn take_last_data_frame(&mut self) -> Option<frame::Data<B>> {
         self.encoder.last_data_frame.take()
+    }
+
+    /// [impit patch] Set the pseudo-header order for HEADERS frames on this connection.
+    pub fn set_pseudo_header_order(&mut self, order: Vec<String>) {
+        self.encoder.pseudo_header_order = Some(order);
     }
 
     pub fn get_mut(&mut self) -> &mut T {

--- a/src/codec/framed_write.rs
+++ b/src/codec/framed_write.rs
@@ -258,13 +258,21 @@ where
             }
             Frame::Headers(v) => {
                 let mut buf = limited_write_buf!(self);
-                if let Some(continuation) = v.encode(&mut self.hpack, self.pseudo_header_order.as_deref(), &mut buf) {
+                if let Some(continuation) = v.encode(
+                    &mut self.hpack,
+                    self.pseudo_header_order.as_deref(),
+                    &mut buf,
+                ) {
                     self.next = Some(Next::Continuation(continuation));
                 }
             }
             Frame::PushPromise(v) => {
                 let mut buf = limited_write_buf!(self);
-                if let Some(continuation) = v.encode(&mut self.hpack, self.pseudo_header_order.as_deref(), &mut buf) {
+                if let Some(continuation) = v.encode(
+                    &mut self.hpack,
+                    self.pseudo_header_order.as_deref(),
+                    &mut buf,
+                ) {
                     self.next = Some(Next::Continuation(continuation));
                 }
             }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -105,6 +105,11 @@ impl<T, B> Codec<T, B> {
         self.inner.set_max_header_list_size(val);
     }
 
+    /// [impit patch] Set the pseudo-header order for HEADERS frames on this connection.
+    pub fn set_pseudo_header_order(&mut self, order: Vec<String>) {
+        self.framed_write().set_pseudo_header_order(order);
+    }
+
     /// Get a reference to the inner stream.
     #[cfg(feature = "unstable")]
     pub fn get_ref(&self) -> &T {

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -97,12 +97,8 @@ static VALID_PSEUDOHEADERS: [&str; 6] = [
 ];
 
 /// Default pseudo-header order for requests (only the 4 request pseudo-headers).
-static DEFAULT_REQUEST_PSEUDOHEADER_ORDER: [&str; 4] = [
-    ":method",
-    ":scheme",
-    ":authority",
-    ":path",
-];
+static DEFAULT_REQUEST_PSEUDOHEADER_ORDER: [&str; 4] =
+    [":method", ":scheme", ":authority", ":path"];
 
 #[derive(Debug)]
 struct PseudoheadersOrder {
@@ -1014,13 +1010,19 @@ impl HeaderBlock {
         Ok(())
     }
 
-    fn into_encoding(self, encoder: &mut hpack::Encoder, pseudo_header_order: Option<&[String]>) -> EncodingHeaderBlock {
+    fn into_encoding(
+        self,
+        encoder: &mut hpack::Encoder,
+        pseudo_header_order: Option<&[String]>,
+    ) -> EncodingHeaderBlock {
         let mut hpack = BytesMut::new();
 
         // [impit patch] Use per-connection pseudo-header order if provided,
         // otherwise fall back to env var (for backward compatibility) or default.
         let order = match pseudo_header_order {
-            Some(order) => PseudoheadersOrder { inner: order.to_vec() },
+            Some(order) => PseudoheadersOrder {
+                inner: order.to_vec(),
+            },
             None => PseudoheadersOrder::load(),
         };
 
@@ -1105,7 +1107,11 @@ mod test {
         );
 
         let continuation = headers
-            .encode(&mut encoder, None, &mut (&mut dst).limit(frame::HEADER_LEN + 8))
+            .encode(
+                &mut encoder,
+                None,
+                &mut (&mut dst).limit(frame::HEADER_LEN + 8),
+            )
             .unwrap();
 
         assert_eq!(17, dst.len());
@@ -1401,7 +1407,10 @@ mod test {
             .expect("decode failed");
 
         // Pseudo-headers should appear in the custom order
-        assert!(decoded_headers.len() >= 4, "expected at least 4 pseudo-headers");
+        assert!(
+            decoded_headers.len() >= 4,
+            "expected at least 4 pseudo-headers"
+        );
 
         // Verify order: path, method, scheme, authority
         assert!(

--- a/src/frame/headers.rs
+++ b/src/frame/headers.rs
@@ -86,7 +86,8 @@ pub struct Iter {
     pseudo_order: PseudoheadersOrder,
 }
 
-static PSEUDOHEADERS: [&str; 6] = [
+/// All valid HTTP/2 pseudo-headers (for validation).
+static VALID_PSEUDOHEADERS: [&str; 6] = [
     ":method",
     ":scheme",
     ":authority",
@@ -95,33 +96,44 @@ static PSEUDOHEADERS: [&str; 6] = [
     ":status",
 ];
 
+/// Default pseudo-header order for requests (only the 4 request pseudo-headers).
+static DEFAULT_REQUEST_PSEUDOHEADER_ORDER: [&str; 4] = [
+    ":method",
+    ":scheme",
+    ":authority",
+    ":path",
+];
+
 #[derive(Debug)]
 struct PseudoheadersOrder {
     pub inner: Vec<String>,
 }
 
 impl PseudoheadersOrder {
+    /// Load pseudo-header order from IMPIT_H2_PSEUDOHEADERS_ORDER env var.
+    /// If not set, uses the default request pseudo-header order.
+    /// [impit patch] The env var only needs to contain the pseudo-headers relevant
+    /// to the request (typically: :method, :authority/:path, :scheme, :path/:authority).
+    /// Response pseudo-headers (:status) and Extended CONNECT (:protocol) are optional.
     pub fn load() -> Self {
-        let pseudo_env_var_order =
-            std::env::var("IMPIT_H2_PSEUDOHEADERS_ORDER").unwrap_or(PSEUDOHEADERS.join(","));
+        let order_str = std::env::var("IMPIT_H2_PSEUDOHEADERS_ORDER")
+            .unwrap_or_else(|_| DEFAULT_REQUEST_PSEUDOHEADER_ORDER.join(","));
 
-        PseudoheadersOrder::from(pseudo_env_var_order)
+        PseudoheadersOrder::from(order_str)
     }
 }
 
 impl From<String> for PseudoheadersOrder {
     fn from(order: String) -> Self {
-        let parsed: Vec<String> = order.split(",").map(|s| s.to_string()).collect();
+        let parsed: Vec<String> = order.split(',').map(|s| s.to_string()).collect();
 
+        // [impit patch] Only validate that provided headers are valid pseudo-headers.
+        // Don't require ALL pseudo-headers to be present -- a request only needs
+        // :method, :scheme, :authority, :path. :status is response-only and
+        // :protocol is for Extended CONNECT only.
         for header in parsed.iter() {
-            if !PSEUDOHEADERS.contains(&header.as_str()) {
+            if !VALID_PSEUDOHEADERS.contains(&header.as_str()) {
                 panic!("[impit patch] Invalid pseudoheader: {}", header);
-            }
-        }
-
-        for header in PSEUDOHEADERS.iter() {
-            if !parsed.contains(&header.to_string()) {
-                panic!("[impit patch] Missing pseudoheader: {}", header);
             }
         }
 
@@ -320,6 +332,7 @@ impl Headers {
     pub fn encode(
         self,
         encoder: &mut hpack::Encoder,
+        pseudo_header_order: Option<&[String]>,
         dst: &mut EncodeBuf<'_>,
     ) -> Option<Continuation> {
         // At this point, the `is_end_headers` flag should always be set
@@ -329,7 +342,7 @@ impl Headers {
         let head = self.head();
 
         self.header_block
-            .into_encoding(encoder)
+            .into_encoding(encoder, pseudo_header_order)
             .encode(&head, dst, |_| {})
     }
 
@@ -541,6 +554,7 @@ impl PushPromise {
     pub fn encode(
         self,
         encoder: &mut hpack::Encoder,
+        pseudo_header_order: Option<&[String]>,
         dst: &mut EncodeBuf<'_>,
     ) -> Option<Continuation> {
         // At this point, the `is_end_headers` flag should always be set
@@ -550,7 +564,7 @@ impl PushPromise {
         let promised_id = self.promised_id;
 
         self.header_block
-            .into_encoding(encoder)
+            .into_encoding(encoder, pseudo_header_order)
             .encode(&head, dst, |dst| {
                 dst.put_u32(promised_id.into());
             })
@@ -1000,13 +1014,20 @@ impl HeaderBlock {
         Ok(())
     }
 
-    fn into_encoding(self, encoder: &mut hpack::Encoder) -> EncodingHeaderBlock {
+    fn into_encoding(self, encoder: &mut hpack::Encoder, pseudo_header_order: Option<&[String]>) -> EncodingHeaderBlock {
         let mut hpack = BytesMut::new();
+
+        // [impit patch] Use per-connection pseudo-header order if provided,
+        // otherwise fall back to env var (for backward compatibility) or default.
+        let order = match pseudo_header_order {
+            Some(order) => PseudoheadersOrder { inner: order.to_vec() },
+            None => PseudoheadersOrder::load(),
+        };
 
         let headers = Iter {
             pseudo: Some(self.pseudo),
             fields: self.fields.into_iter(),
-            pseudo_order: PseudoheadersOrder::load(),
+            pseudo_order: order,
         };
 
         encoder.encode(headers, &mut hpack);
@@ -1057,7 +1078,7 @@ fn decoded_header_size(name: usize, value: usize) -> usize {
 mod test {
     use super::*;
     use crate::frame;
-    use crate::hpack::{huffman, Encoder};
+    use crate::hpack::{huffman, Decoder, Encoder};
 
     #[test]
     fn test_nameless_header_at_resume() {
@@ -1084,7 +1105,7 @@ mod test {
         );
 
         let continuation = headers
-            .encode(&mut encoder, &mut (&mut dst).limit(frame::HEADER_LEN + 8))
+            .encode(&mut encoder, None, &mut (&mut dst).limit(frame::HEADER_LEN + 8))
             .unwrap();
 
         assert_eq!(17, dst.len());
@@ -1274,5 +1295,150 @@ mod test {
                 }
             );
         }
+    }
+
+    // ===== impit patch tests =====
+
+    #[test]
+    fn test_pseudoheaders_order_from_valid_string() {
+        let order = PseudoheadersOrder::from(":method,:scheme,:authority,:path".to_string());
+        assert_eq!(
+            order.inner,
+            vec![":method", ":scheme", ":authority", ":path"]
+        );
+
+        let order = PseudoheadersOrder::from(":path,:method,:scheme,:authority".to_string());
+        assert_eq!(
+            order.inner,
+            vec![":path", ":method", ":scheme", ":authority"]
+        );
+
+        // Subset is valid (e.g. response only needs :status)
+        let order = PseudoheadersOrder::from(":status".to_string());
+        assert_eq!(order.inner, vec![":status"]);
+
+        // All 6 valid pseudo-headers
+        let order = PseudoheadersOrder::from(
+            ":method,:scheme,:authority,:path,:protocol,:status".to_string(),
+        );
+        assert_eq!(order.inner.len(), 6);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid pseudoheader")]
+    fn test_pseudoheaders_order_from_invalid_panics() {
+        let _ = PseudoheadersOrder::from(":method,:bogus".to_string());
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid pseudoheader")]
+    fn test_pseudoheaders_order_from_non_pseudo_panics() {
+        let _ = PseudoheadersOrder::from("content-type".to_string());
+    }
+
+    #[test]
+    fn test_pseudoheaders_order_load_env_var() {
+        // Test default (env var unset)
+        std::env::remove_var("IMPIT_H2_PSEUDOHEADERS_ORDER");
+        let order = PseudoheadersOrder::load();
+        assert_eq!(
+            order.inner,
+            vec![":method", ":scheme", ":authority", ":path"]
+        );
+
+        // Test with env var set
+        std::env::set_var(
+            "IMPIT_H2_PSEUDOHEADERS_ORDER",
+            ":path,:method,:scheme,:authority",
+        );
+        let order = PseudoheadersOrder::load();
+        assert_eq!(
+            order.inner,
+            vec![":path", ":method", ":scheme", ":authority"]
+        );
+
+        // Clean up
+        std::env::remove_var("IMPIT_H2_PSEUDOHEADERS_ORDER");
+    }
+
+    #[test]
+    fn test_encoding_respects_custom_pseudo_header_order() {
+        let mut encoder = Encoder::default();
+
+        let pseudo = Pseudo {
+            method: Method::GET.into(),
+            scheme: BytesStr::from_static("https").into(),
+            authority: BytesStr::from_static("example.com").into(),
+            path: BytesStr::from_static("/test").into(),
+            ..Default::default()
+        };
+
+        let block = HeaderBlock {
+            fields: HeaderMap::new(),
+            field_size: 0,
+            is_over_size: false,
+            pseudo,
+        };
+
+        // Custom order: path, method, scheme, authority (different from default)
+        let custom_order: Vec<String> = vec![
+            ":path".into(),
+            ":method".into(),
+            ":scheme".into(),
+            ":authority".into(),
+        ];
+
+        let encoding = block.into_encoding(&mut encoder, Some(&custom_order));
+
+        // Decode and verify order
+        let mut decoder = Decoder::new(0);
+        let mut decoded_headers = Vec::new();
+        let mut hpack_bytes = BytesMut::from(encoding.hpack.as_ref());
+        decoder
+            .decode(&mut std::io::Cursor::new(&mut hpack_bytes), |h| {
+                decoded_headers.push(h);
+            })
+            .expect("decode failed");
+
+        // Pseudo-headers should appear in the custom order
+        assert!(decoded_headers.len() >= 4, "expected at least 4 pseudo-headers");
+
+        // Verify order: path, method, scheme, authority
+        assert!(
+            matches!(&decoded_headers[0], hpack::Header::Path(p) if p.as_ref() == b"/test"),
+            "first header should be :path, got {:?}",
+            decoded_headers[0]
+        );
+        assert!(
+            matches!(&decoded_headers[1], hpack::Header::Method(m) if *m == Method::GET),
+            "second header should be :method, got {:?}",
+            decoded_headers[1]
+        );
+        assert!(
+            matches!(&decoded_headers[2], hpack::Header::Scheme(s) if s.as_ref() == b"https"),
+            "third header should be :scheme, got {:?}",
+            decoded_headers[2]
+        );
+        assert!(
+            matches!(&decoded_headers[3], hpack::Header::Authority(a) if a.as_ref() == b"example.com"),
+            "fourth header should be :authority, got {:?}",
+            decoded_headers[3]
+        );
+    }
+
+    #[test]
+    fn test_default_pseudoheader_constants() {
+        assert_eq!(VALID_PSEUDOHEADERS.len(), 6);
+        assert!(VALID_PSEUDOHEADERS.contains(&":method"));
+        assert!(VALID_PSEUDOHEADERS.contains(&":scheme"));
+        assert!(VALID_PSEUDOHEADERS.contains(&":authority"));
+        assert!(VALID_PSEUDOHEADERS.contains(&":path"));
+        assert!(VALID_PSEUDOHEADERS.contains(&":protocol"));
+        assert!(VALID_PSEUDOHEADERS.contains(&":status"));
+
+        assert_eq!(
+            DEFAULT_REQUEST_PSEUDOHEADER_ORDER,
+            [":method", ":scheme", ":authority", ":path"]
+        );
     }
 }

--- a/src/frame/settings.rs
+++ b/src/frame/settings.rs
@@ -38,7 +38,8 @@ const ACK: u8 = 0x1;
 const ALL: u8 = ACK;
 
 /// The default value of SETTINGS_HEADER_TABLE_SIZE
-pub const DEFAULT_SETTINGS_HEADER_TABLE_SIZE: usize = 4_096;
+/// [impit patch] Changed from 4096 to 65536 to match real browsers (Chrome, Firefox, Edge all use 65536).
+pub const DEFAULT_SETTINGS_HEADER_TABLE_SIZE: usize = 65_536;
 
 /// The default value of SETTINGS_INITIAL_WINDOW_SIZE
 pub const DEFAULT_INITIAL_WINDOW_SIZE: u32 = 65_535;
@@ -385,5 +386,17 @@ impl fmt::Debug for SettingsFlags {
         util::debug_flags(f, self.0)
             .flag_if(self.is_ack(), "ACK")
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_default_header_table_size_is_browser_value() {
+        // [impit patch] Must be 65536 to match real browsers (Chrome, Firefox, Edge).
+        // The upstream default of 4096 is a fingerprinting giveaway.
+        assert_eq!(DEFAULT_SETTINGS_HEADER_TABLE_SIZE, 65_536);
     }
 }


### PR DESCRIPTION
- Introduced per-connection pseudo-header order for HEADERS frames, allowing different browsers to use their respective orders.
- Updated connection creation to read pseudo-header order and MAX_CONCURRENT_STREAMS from environment variables, improving flexibility.
- Set default HEADER_TABLE_SIZE to 65536 to align with real browsers, enhancing fingerprinting resistance.
- Added validation for pseudo-header orders and corresponding tests to ensure correctness.

This change significantly improves compatibility with various browsers and optimizes connection handling.